### PR TITLE
Make CI (fmt, clippy) pass, fill in TODOs in documentation

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -132,7 +132,7 @@ fn shim_public_key(
     let key = match key_type {
         KeyType::Ed25519 => HEXLOWER.encode(public_key),
         KeyType::Rsa | KeyType::Unknown(_) => {
-            let bytes = write_spki(public_key, &key_type)?;
+            let bytes = write_spki(public_key, key_type)?;
             BASE64URL.encode(&bytes)
         }
     };

--- a/src/format_hex.rs
+++ b/src/format_hex.rs
@@ -2,7 +2,7 @@ use data_encoding::HEXLOWER;
 use serde::{self, Deserialize, Deserializer, Serializer};
 use std::result::Result;
 
-pub fn serialize<S>(value: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
+pub fn serialize<S>(value: &[u8], serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {

--- a/src/interchange/mod.rs
+++ b/src/interchange/mod.rs
@@ -32,6 +32,7 @@ pub trait DataInterchange: Debug + PartialEq + Clone {
         T: Serialize;
 
     /// Write a struct to a stream.
+    #[allow(clippy::wrong_self_convention)]
     fn to_writer<W, T: Sized>(writer: W, value: &T) -> Result<()>
     where
         W: Write,

--- a/src/models/helpers.rs
+++ b/src/models/helpers.rs
@@ -12,14 +12,14 @@ use crate::Result;
 use crate::error::Error;
 
 #[rustfmt::skip]
-static PATH_ILLEGAL_COMPONENTS: &'static [&str] = &[
+static PATH_ILLEGAL_COMPONENTS: &[&str] = &[
     ".", // current dir
     "..", // parent dir
          // TODO ? "0", // may translate to nul in windows
 ];
 
 #[rustfmt::skip]
-static PATH_ILLEGAL_COMPONENTS_CASE_INSENSITIVE: &'static [&str] = &[
+static PATH_ILLEGAL_COMPONENTS_CASE_INSENSITIVE: &[&str] = &[
     // DOS device files
     "CON",
     "PRN",
@@ -51,7 +51,7 @@ static PATH_ILLEGAL_COMPONENTS_CASE_INSENSITIVE: &'static [&str] = &[
 ];
 
 #[rustfmt::skip]
-static PATH_ILLEGAL_STRINGS: &'static [&str] = &[
+static PATH_ILLEGAL_STRINGS: &[&str] = &[
     ":", // for *nix compatibility
     "\\", // for windows compatibility
     "<",

--- a/src/models/link/metadata.rs
+++ b/src/models/link/metadata.rs
@@ -22,6 +22,12 @@ pub struct LinkMetadataBuilder {
     byproducts: BTreeMap<String, String>,
 }
 
+impl Default for LinkMetadataBuilder {
+    fn default() -> Self {
+        LinkMetadataBuilder::new()
+    }
+}
+
 impl LinkMetadataBuilder {
     pub fn new() -> Self {
         LinkMetadataBuilder {

--- a/src/models/metadata.rs
+++ b/src/models/metadata.rs
@@ -237,7 +237,7 @@ where
             .collect::<HashMap<&KeyId, &Signature>>();
         for (key_id, sig) in signatures {
             match authorized_keys.get(key_id) {
-                Some(ref pub_key) => match pub_key.verify(&canonical_bytes, sig) {
+                Some(pub_key) => match pub_key.verify(&canonical_bytes, sig) {
                     Ok(()) => {
                         debug!("Good signature from key ID {:?}", pub_key.key_id());
                         signatures_needed -= 1;

--- a/src/runlib.rs
+++ b/src/runlib.rs
@@ -17,8 +17,6 @@ use crate::{
 };
 use crate::{Error, Result};
 
-// TODO: improve doc comments :p
-
 /// Reads and hashes an artifact given its path as a string literal,
 /// returning the `VirtualTargetPath` and `TargetDescription` of the file as a tuple, wrapped in `Result`.
 pub fn record_artifact(
@@ -211,13 +209,13 @@ pub fn run_command(cmd_args: &[&str], run_dir: Option<&str>) -> Result<BTreeMap<
 /// If a symbolic link cycle is detected in the material or product paths, paths causing the cycle are skipped.
 /// # Arguments
 ///
-/// * `name` - TODO
-/// * `run_dir` - TODO
-/// * `material_paths` - TODO
-/// * `product_paths` - TODO
-/// * `cmd_args` - TODO
-/// * `key` - TODO
-/// * `hash_algorithms` - TODO
+/// * `name` - The unique string used to associate link metadata with a step or inspection.
+/// * `run_dir` - A string slice (`&str`) wrapped in an `Option` that holds the directory the commands are to be ran. If `None` is provided, the current directory is assumed as default.
+/// * `material_paths` - A string slice (`&str`) of artifact paths to be recorded before command execution. Directories are traversed recursively.
+/// * `product_paths` - A string slice (`&str`) of artifact paths to be recorded after command execution. Directories are traversed recursively.
+/// * `cmd_args` - A string slice (`&str`) where the first element is a command and the remaining elements are arguments passed to that command.
+/// * `key` -  A key used to sign the resulting link metadata.
+/// * `hash_algorithms` - An array of string slice (`&str`) wrapped in an `Option` that holds the hash algorithms to be used. If `None` is provided, Sha256 is assumed as default.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
- [x] Run `cargo fmt`
- [x] Address clippy warnings
- [x] Address TODOs within `cargo doc`