### PR TITLE
Update dependencies to tokio 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-target
+/target/
+/Cargo.lock
+/tests/hello_intoto

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,16 +20,16 @@ path = "./src/lib.rs"
 [dependencies]
 chrono = { version = "0.4", features = [ "serde" ] }
 data-encoding = "2.0.0-rc.2"
-derp = "0.0.13"
+derp = "0.0.14"
 futures-executor = "0.3.1"
 futures-io = "0.3.1"
 futures-util = { version = "0.3.1", features = [ "compat", "io" ] }
-http = "0.1"
-hyper = { version = "0.12", default-features = false }
+http = "0.2"
+hyper = { version = "0.14", default-features = false }
 itoa = "0.4"
 log = "0.4"
 ring = { version = "0.16" }
-parking_lot = "0.9"
+parking_lot = "0.11"
 percent-encoding = "2.1"
 serde = "1"
 serde_derive = "1"
@@ -47,7 +47,7 @@ lazy_static = "1.4.0"
 lazy_static = "1"
 maplit = "1"
 matches = "0.1.8"
-pretty_assertions = "0.6"
+pretty_assertions = "0.7"
 
 [features]
 default = ["hyper/default"]

--- a/tests/hello_intoto
+++ b/tests/hello_intoto
@@ -1,1 +1,0 @@
-in_toto says hi


### PR DESCRIPTION
This avoids pulling in an older tokio runtime. No further changes where needed, it seems it's not used by anything at the moment (besides the `From` impl for Error).

Since this is a library crate I'm also adding Cargo.lock to .gitignore, as well as `tests/hello_intoto` which is written to by tests.

I didn't check if this is compatible with 0.1.X or if this needs a 0.2.0 release.

Thanks!