### PR TITLE
Add left-stripping functionality

### DIFF
--- a/examples/in_toto_run_test.rs
+++ b/examples/in_toto_run_test.rs
@@ -14,6 +14,7 @@ fn main() {
         &["sh", "-c", "echo 'in_toto says hi' >> hello_intoto"],
         Some(&key),
         Some(&["sha512", "sha256"]),
+        None,
     )
     .unwrap();
     let json = serde_json::to_value(&link).unwrap();

--- a/src/models/metadata.rs
+++ b/src/models/metadata.rs
@@ -138,9 +138,7 @@ where
                 let sig = key.sign(&bytes)?;
                 vec![sig]
             }
-            None => {
-                vec![]
-            }
+            None => vec![],
         };
 
         Ok(Self {

--- a/src/runlib.rs
+++ b/src/runlib.rs
@@ -31,9 +31,9 @@ pub fn record_artifact(
     Ok((VirtualTargetPath::new(lstripped_path)?, hashes))
 }
 
-/// Given an artifact path in &str format, left strip path for given artifact based a list of `lstrip_paths` provided,
-/// returning the stripped file path in String format wrapped in Result.
-pub fn apply_left_strip(path: &str, lstrip_paths: Option<&[&str]>) -> Result<String> {
+/// Given an artifact path in `&str` format, left strip path for given artifact based an optional array of `lstrip_paths` provided,
+/// returning the stripped file path in String format wrapped in `Result`.
+fn apply_left_strip(path: &str, lstrip_paths: Option<&[&str]>) -> Result<String> {
     // If lstrip_paths is None, skip strip.
     // Else, check if path starts with any given lstrip paths and strip
     if let Some(l_paths) = lstrip_paths {
@@ -62,6 +62,7 @@ pub fn apply_left_strip(path: &str, lstrip_paths: Option<&[&str]>) -> Result<Str
 ///
 /// * `paths` - An array of string slices (`&str`) that holds the paths to be traversed. If a symbolic link cycle is detected in the `paths` during traversal, it is skipped.
 /// * `hash_algorithms` - An array of string slice (`&str`) wrapped in an `Option` that holds the hash algorithms to be used. If `None` is provided, Sha256 is assumed as default.
+/// * `lstrip_paths` - An array of path prefixes (`&str`) wrapped in an `Option` used to left-strip artifact paths before storing them in the resulting link metadata.
 ///
 /// # Examples
 ///
@@ -244,6 +245,7 @@ pub fn run_command(cmd_args: &[&str], run_dir: Option<&str>) -> Result<BTreeMap<
 /// * `cmd_args` - A string slice (`&str`) where the first element is a command and the remaining elements are arguments passed to that command.
 /// * `key` -  A key used to sign the resulting link metadata.
 /// * `hash_algorithms` - An array of string slice (`&str`) wrapped in an `Option` that holds the hash algorithms to be used. If `None` is provided, Sha256 is assumed as default.
+/// * `lstrip_paths` - An array of path prefixes (`&str`) wrapped in an `Option` used to left-strip artifact paths before storing them in the resulting link metadata.
 ///
 /// # Examples
 ///

--- a/tests/runlib.rs
+++ b/tests/runlib.rs
@@ -73,6 +73,7 @@ fn in_toto_run_record_file() {
         &["sh", "-c", "echo 'in_toto says hi'"],
         Some(&TEST_PRIVATE_KEY),
         None,
+        None,
     )
     .unwrap();
 
@@ -105,6 +106,7 @@ fn in_toto_run_record_new_file() {
             &format!("echo 'in_toto says hi' >> {}/bar.txt", dir_path),
         ],
         Some(&TEST_PRIVATE_KEY),
+        None,
         None,
     )
     .unwrap();
@@ -176,6 +178,7 @@ fn in_toto_run_record_symlink_file() {
         &vec![dir_path],
         &["sh", "-c", "echo 'in_toto says hi'"],
         Some(&TEST_PRIVATE_KEY),
+        None,
         None,
     )
     .unwrap();


### PR DESCRIPTION
This PR fixes https://github.com/in-toto/in-toto-rs/issues/13 and includes the following additions:
- Introduces a new optional input `lstrip_paths` to `in_toto_run` addressing rebuilderd absolute paths & future usages. 
- Add private function `apply_left_strip`: Given an artifact path in `&str` format, left strip path for given artifact based an optional array of `lstrip_paths` provided, returning the stripped file path in String format wrapped in `Result`.

**Please verify and check that the pull request fulfills the following requirements:**
- [x]  Tests have been added for the bug fix or new feature
- [x]  Docs have been added for the bug fix or new feature