### PR TITLE
add left-stripping functionality and unique check

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,9 @@ pub enum Error {
     /// The metadata or target failed to verify.
     #[error("verification failure: {0}")]
     VerificationFailure(String),
+
+    #[error("prefix selection failure: {0}")]
+    LinkGatheringError(String),
 }
 
 impl From<serde_json::error::Error> for Error {

--- a/src/models/helpers.rs
+++ b/src/models/helpers.rs
@@ -1,13 +1,10 @@
 //! Supporting Functions and Types (VirtualTargetPath)
 use crate::crypto::{HashAlgorithm, HashValue};
-use crate::error::Error;
 use crate::Result;
 use serde::de::{Deserialize, Deserializer, Error as DeserializeError};
 use serde_derive::Serialize;
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::fs::canonicalize as canonicalize_path;
-use std::path::Path;
 use std::str;
 
 /// Description of a target, used in verification.
@@ -21,16 +18,7 @@ impl VirtualTargetPath {
     /// Create a new `VirtualTargetPath` from a `String`.
     ///
     pub fn new(path: String) -> Result<Self> {
-        let cleaned_path = match canonicalize_path(Path::new(path.as_str())) {
-            Ok(path_buf) => match path_buf.to_str() {
-                Some(x) => x.to_string(),
-                None => {
-                    return Err(Error::VerificationFailure("Couldn't find Path".to_string()));
-                }
-            },
-            Err(e) => return Err(Error::from(e)),
-        };
-        Ok(VirtualTargetPath(cleaned_path))
+        Ok(VirtualTargetPath(path))
     }
 
     /// The string value of the path.

--- a/tests/test_prefix/left/world
+++ b/tests/test_prefix/left/world
@@ -1,0 +1,1 @@
+lorem ipsum

--- a/tests/test_prefix/right/world
+++ b/tests/test_prefix/right/world
@@ -1,0 +1,1 @@
+lorem ipsum


### PR DESCRIPTION
based on the work of @joyliu-q 
fix #13 

- [x] add left-stripping functionality `apply_left_strip`
- [x] add unique check of left-stripped files and raise `LinkGatheringError`
https://github.com/in-toto/in-toto-golang/issues/139
- [x] copy `hello./world` to `tests/test_prefix/left/world` and `tests/test_prefix/right/world` for left-stripping testing
- [x] add new testcases
- [x] when user entering two possible path for a file target, auto choose `longer` prefix

For example, `tests/` and `tests/test_runlib` for target `tests/test_runlib/.hidden/world` will lead to prefix `tests/test_runlib`.

❗  remove exist check inside `VirtualTargetPath::new` as relative path after left-stripping will be hardly to check existence, and **golang version doesn't check it either**