### PR TITLE
add example loading key created with in-toto-keygen

### DIFF
--- a/examples/keygen_example/ed25519
+++ b/examples/keygen_example/ed25519
@@ -1,0 +1,1 @@
+{"keytype": "ed25519", "scheme": "ed25519", "keyid": "e1290b366164533938c61973a8538d8de8ea9a1883db04da8a0e64fc63255ecc", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "2fdff7e7bfbe869ad9673273c76c789b319948e62a81ab28a5712acefc331536", "private": "6329b7c1142215ed31be4f5f5e6f6cd1e2a26bdc1f61958eea3f51f349d0f8ce"}}

--- a/examples/keygen_example/ed25519.pub
+++ b/examples/keygen_example/ed25519.pub
@@ -1,0 +1,1 @@
+{"keytype": "ed25519", "scheme": "ed25519", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "2fdff7e7bfbe869ad9673273c76c789b319948e62a81ab28a5712acefc331536"}}

--- a/examples/load_keys_from_keygen.rs
+++ b/examples/load_keys_from_keygen.rs
@@ -1,0 +1,24 @@
+use std::fs;
+
+use data_encoding::HEXLOWER;
+use serde_json::Value;
+
+use in_toto::crypto::PrivateKey;
+
+fn main() {
+    // Load a Ed25519 signing key
+    let json_key_data = fs::read_to_string("examples/keygen_example/ed25519").unwrap();
+    let data: Value = serde_json::from_str(&json_key_data).unwrap();
+
+    let private_key_raw = data["keyval"]["private"].as_str().unwrap().as_bytes();
+    let public_key_raw = data["keyval"]["public"].as_str().unwrap().as_bytes();
+
+    let mut private_key = HEXLOWER.decode(private_key_raw).unwrap();
+    let public_key = HEXLOWER.decode(public_key_raw).unwrap();
+
+    private_key.extend(public_key);
+
+    let privkey = PrivateKey::from_ed25519(&private_key).unwrap();
+
+    println!("loaded keypair: {:?}", &privkey.public())
+}


### PR DESCRIPTION
fix #1 

run `load_keys_from_keygen.rs` with stdout:
```
loaded keypair: PublicKey { typ: Ed25519, key_id: KeyId("be243aae277567627439068209d07391f2260fd318663e447564407af6390558"), scheme: Ed25519, keyid_hash_algorithms: None, value: PublicKeyValue("2fdff7e7bfbe869ad9673273c76c789b319948e62a81ab28a5712acefc331536") }
```

Signed-off-by: cutecutecat <starkind1997@gmail.com>