### PR TITLE
feat: add Pre-Authentication Encoding(pae) for DSSE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ walkdir = "2"
 path-clean = "0.1.0"
 rand = "0.8.4"
 lazy_static = "1.4.0"
+once_cell = "1.10.0"
+strum = "0.24"
+strum_macros = "0.24"
 
 [dev-dependencies]
 lazy_static = "1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@
 use data_encoding::DecodeError;
 use std::io;
 use std::path::Path;
+use std::str;
 use thiserror::Error;
 
 /// Error type for all in-toto related errors.
@@ -56,6 +57,9 @@ pub enum Error {
 
     #[error("prefix selection failure: {0}")]
     LinkGatheringError(String),
+
+    #[error("do Pre-Authentication Encoding failed: {0}")]
+    PAEParseFailed(String),
 }
 
 impl From<serde_json::error::Error> for Error {
@@ -107,6 +111,12 @@ impl From<derp::Error> for Error {
 impl From<tempfile::PersistError> for Error {
     fn from(err: tempfile::PersistError) -> Error {
         Error::Opaque(format!("Error persisting temp file: {:?}", err))
+    }
+}
+
+impl From<str::Utf8Error> for Error {
+    fn from(err: str::Utf8Error) -> Error {
+        Error::Opaque(format!("Parse utf8: {:?}", err))
     }
 }
 

--- a/src/models/envelope/mod.rs
+++ b/src/models/envelope/mod.rs
@@ -1,0 +1,87 @@
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
+
+use self::pae_v1::PaeV1;
+use crate::{Error, Result};
+
+mod pae_v1;
+
+pub trait DSSEParser {
+    fn pae_pack(payload_ver: String, payload: &[u8]) -> Vec<u8>;
+    fn pae_unpack(bytes: &[u8]) -> Result<(Vec<u8>, String)>;
+}
+
+/// DSSE global packer and unpacker.
+#[derive(EnumIter, PartialEq, Eq, Hash, Clone, Copy)]
+pub enum DSSEVersion {
+    V1,
+}
+
+impl DSSEVersion {
+    /// Use Pre-Authentication Encoding to pack payload for any version.
+    #[allow(dead_code)]
+    // TODO: remove #[allow(dead_code)] after metadata deploy
+    pub fn pack(&self, payload: &[u8], payload_ver: String) -> Vec<u8> {
+        let payload = payload.to_vec();
+
+        match self {
+            DSSEVersion::V1 => PaeV1::pae_pack(payload_ver, &payload),
+        }
+    }
+
+    /// Use Pre-Authentication Encoding to unpack payload for any version.
+    pub fn unpack(&self, bytes: &[u8]) -> Result<(Vec<u8>, String)> {
+        // Note: if two of the versions is compatible with each other
+        // `try_unpack` may failed to find the right version.
+        let (payload, payload_ver) = match self {
+            DSSEVersion::V1 => PaeV1::pae_unpack(bytes)?,
+        };
+        Ok((payload, payload_ver))
+    }
+
+    /// Use Pre-Authentication Encoding to auto unpack a possiable version.
+    #[allow(dead_code)]
+    // TODO: remove #[allow(dead_code)] after metadata deploy
+    pub fn try_unpack(bytes: &[u8]) -> Result<(Vec<u8>, String)> {
+        let mut file: Result<(Vec<u8>, String)> =
+            Err(Error::Programming("no available DSSE parser".to_string()));
+        for method in DSSEVersion::iter() {
+            file = method.unpack(bytes);
+            if file.is_ok() {
+                break;
+            }
+        }
+        file
+    }
+}
+
+#[cfg(test)]
+mod pae_test {
+    use once_cell::sync::Lazy;
+
+    pub struct EnvelopeFileTuple {
+        pub(crate) name: String,
+        pub(crate) inner_payload: &'static str,
+        pub(crate) payload_ver: String,
+    }
+
+    pub static SERIALIZE_SRC_DATAS: Lazy<Vec<EnvelopeFileTuple>> = Lazy::new(|| {
+        vec![
+            EnvelopeFileTuple {
+                name: "blank_test".to_string(),
+                inner_payload: "",
+                payload_ver: "link".to_string(),
+            },
+            EnvelopeFileTuple {
+                name: "blank_envelope_naive_test".to_string(),
+                inner_payload: "{\"payload\":[],\"payload_type\":\"link\",\"signatures\":[]}",
+                payload_ver: "link".to_string(),
+            },
+            EnvelopeFileTuple {
+                name: "blank_envelope_v01_test".to_string(),
+                inner_payload: "{\"payload\":[],\"payload_type\":\"link\",\"signatures\":[]}",
+                payload_ver: "https://in-toto.io/payloadment/v0.1".to_string(),
+            },
+        ]
+    });
+}

--- a/src/models/envelope/pae_v1.rs
+++ b/src/models/envelope/pae_v1.rs
@@ -1,0 +1,131 @@
+use std::str;
+
+use super::DSSEParser;
+use crate::Error;
+use crate::Result;
+
+const PREFIX: &str = "DSSEv1";
+const SPLIT: &str = " ";
+const SPLIT_U8: u8 = 0x20;
+
+pub struct PaeV1;
+
+/// Extract length and payload from bytes and consume them
+///
+/// length, SPLIT, next -> (length, next)
+fn consume_load_len(raw: &[u8]) -> Result<(usize, &[u8])> {
+    let mut iter = raw.splitn(2, |num| *num == SPLIT_U8);
+    let length_raw = iter.next().ok_or_else(|| {
+        Error::PAEParseFailed(format!("split '{}' failed for {:?}", SPLIT, raw.to_owned()))
+    })?;
+
+    let length = str::from_utf8(length_raw)?
+        .parse::<usize>()
+        .map_err(|_| Error::PAEParseFailed(format!("parse to int failed for {:?}", length_raw)))?;
+    let next = iter.next().ok_or_else(|| {
+        Error::PAEParseFailed(format!(
+            "prefix {} strip failed for {:?}",
+            PREFIX,
+            raw.to_owned()
+        ))
+    })?;
+    Ok((length, next))
+}
+
+impl DSSEParser for PaeV1 {
+    /// Use Pre-Authentication Encoding to pack payload for DSSE v1.
+    fn pae_pack(payload_ver: String, payload: &[u8]) -> Vec<u8> {
+        let sig_header: String = format!(
+            "{prefix}{split}{payload_ver_len}{split}{payload_ver}{split}{payload_len}{split}",
+            prefix = PREFIX,
+            split = SPLIT,
+            payload_ver_len = payload_ver.as_bytes().len(),
+            payload_ver = payload_ver.as_str(),
+            payload_len = payload.len(),
+        );
+        let sig = [sig_header.as_bytes(), payload].concat();
+        sig
+    }
+
+    /// Use Pre-Authentication Encoding to unpack payload for DSSE v1.
+    fn pae_unpack(bytes: &[u8]) -> Result<(Vec<u8>, String)> {
+        // Strip prefix + split "DSSEv1 "
+        let raw = bytes
+            .strip_prefix(format!("{}{}", PREFIX, SPLIT).as_bytes())
+            .ok_or_else(|| {
+                Error::PAEParseFailed(format!(
+                    "prefix {} strip failed for {:?}",
+                    PREFIX,
+                    bytes.to_owned()
+                ))
+            })?;
+
+        // Extract payload_ver from bytes
+        let (payload_ver_len, raw) = consume_load_len(raw)?;
+        let payload_ver = str::from_utf8(&raw[0..payload_ver_len])?
+            .parse::<String>()
+            .map_err(|_| Error::PAEParseFailed(format!("parse to string failed for {:?}", raw)))?;
+
+        // Extract payload from bytes
+        let (payload_len, raw) = consume_load_len(&raw[(payload_ver_len + 1)..])?;
+        let payload = raw[0..payload_len].to_vec();
+
+        Ok((payload, payload_ver))
+    }
+}
+
+#[cfg(test)]
+mod pae_test {
+    use std::collections::HashMap;
+    use std::str;
+
+    use once_cell::sync::Lazy;
+
+    use crate::models::envelope::{pae_test::SERIALIZE_SRC_DATAS, DSSEVersion};
+
+    static SERIALIZE_RESULT_DATAS: Lazy<HashMap<String, &str>> = Lazy::new(|| {
+        let real_serialized_file = HashMap::from([
+            ("blank_test".to_string(), "DSSEv1 4 link 0 "),
+            (
+                "blank_envelope_naive_test".to_string(),
+                "DSSEv1 4 link 52 {\"payload\":[],\"payload_type\":\"link\",\"signatures\":[]}",
+            ),
+            (
+                "blank_envelope_v01_test".to_string(),
+                "DSSEv1 35 https://in-toto.io/payloadment/v0.1 52 {\"payload\":[],\"payload_type\":\"link\",\"signatures\":[]}",
+            ),
+        ]);
+        real_serialized_file
+    });
+
+    #[test]
+    fn test_pack() {
+        for file_tuple in SERIALIZE_SRC_DATAS.iter() {
+            let outer = DSSEVersion::V1.pack(
+                file_tuple.inner_payload.as_bytes(),
+                file_tuple.payload_ver.to_owned(),
+            );
+
+            let real = std::str::from_utf8(&outer).unwrap();
+            let right = *SERIALIZE_RESULT_DATAS.get(&file_tuple.name).unwrap();
+            assert_eq!(real, right, "pack assert failed for {}", file_tuple.name);
+        }
+    }
+
+    #[test]
+    fn test_unpack() {
+        for file_tuple in SERIALIZE_SRC_DATAS.iter() {
+            let outer = SERIALIZE_RESULT_DATAS
+                .get(&file_tuple.name)
+                .unwrap()
+                .as_bytes()
+                .to_vec();
+
+            let (inner, _) = DSSEVersion::V1.unpack(&outer).unwrap();
+            let real = str::from_utf8(&inner).unwrap();
+            let right = file_tuple.inner_payload;
+
+            assert_eq!(real, right, "unpack assert failed for {}", file_tuple.name);
+        }
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,5 +1,6 @@
 //! Models used in in-toto
 
+mod envelope;
 mod helpers;
 mod layout;
 mod link;


### PR DESCRIPTION
* add `DSSEVersion` for exposed pae API
* add `PaeV1` for v1 encoding implement
* add error type `PAEParseFailed` and From<Utf8Error> for pae unpack
* add dependency `once_cell` for lazy const variables
* add dependency `strum` and `strum_macros` for iter enums