### PR TITLE
Fix link in metadata.rs doc comment

### DIFF
--- a/src/models/metadata.rs
+++ b/src/models/metadata.rs
@@ -5,7 +5,7 @@
 //! * enum `MetadataWrapper` is used to do serialize, deserialize and
 //! other object unsafe operations.
 //! * trait `Metadata` is used to work for trait object.
-//! The reason please refer to issue https://github.com/in-toto/in-toto-rs/issues/33
+//! The reason please refer to issue <https://github.com/in-toto/in-toto-rs/issues/33>
 //!
 //! # Metablock
 //! Metablock is the container for link metadata and layout metadata.


### PR DESCRIPTION
Currently the following warning is generated when running cargo rustdoc:
```console
$ cargo rustdoc
 Documenting in-toto v0.3.0 (/home/danielbevenius/work/security/in-toto-rs)
warning: this URL is not a hyperlink
 --> src/models/metadata.rs:8:38
  |
8 | //! The reason please refer to issue
  |  https://github.com/in-toto/in-toto-rs/issues/33
  |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic
  |  link instead: `<https://github.com/in-toto/in-toto-rs/issues/33>`
  |
  = note: `#[warn(rustdoc::bare_urls)]` on by default
  = note: bare URLs are not automatically turned into clickable link
```
Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>