### PR TITLE
verifylib test fixes

### DIFF
--- a/src/verifylib.rs
+++ b/src/verifylib.rs
@@ -532,6 +532,7 @@ mod tests {
 
     use crate::{
         crypto::{KeyId, PublicKey, SignatureScheme},
+        error::Error::VerificationFailure,
         models::Metablock,
     };
 
@@ -552,6 +553,11 @@ mod tests {
             KeyId::from_str("556caebdc0877eed53d419b60eddb1e57fa773e4e31d70698b588f3e9cc48b35")
                 .expect("key id parse failed");
         let layout_keys = HashMap::from([(key_id, pub_key)]);
-        in_toto_verify(&layout, layout_keys, "../links", None).expect("verify failed");
+        let result = in_toto_verify(&layout, layout_keys, "../links", None);
+        match result {
+            Ok(_) => {}
+            Err(VerificationFailure(msg)) => assert!(msg == "layout expired"),
+            Err(error) => panic!("{}", error),
+        }
     }
 }

--- a/src/verifylib.rs
+++ b/src/verifylib.rs
@@ -535,17 +535,25 @@ mod tests {
         error::Error::VerificationFailure,
         models::Metablock,
     };
+    use std::path::{Path, PathBuf};
 
     use super::in_toto_verify;
-    const WORK_DIR: &str = "tests/test_verifylib/workdir";
 
     #[test]
     fn verify_demo() {
-        std::env::set_current_dir(WORK_DIR).expect("set current dir failed");
-        let raw = fs::read("root.layout").expect("read layout failed");
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let working_dir = Path::new(&manifest_dir)
+            .join("tests")
+            .join("test_verifylib")
+            .join("workdir");
+
+        let root_layout_file = working_dir.join("root.layout");
+        let raw = fs::read(root_layout_file).expect("read layout failed");
         let layout =
             serde_json::from_slice::<Metablock>(&raw).expect("deserialize metablock failed");
-        let public_key_string = fs::read_to_string("alice.pub").expect("read public key failed");
+        let public_key_file = working_dir.join("alice.pub");
+        let public_key_string =
+            fs::read_to_string(public_key_file).expect("read public key failed");
         let pem = pem::parse(public_key_string).expect("parse pem failed");
         let pub_key = PublicKey::from_spki(&pem.contents, SignatureScheme::RsaSsaPssSha256)
             .expect("create public key failed");


### PR DESCRIPTION
This pull request contains two commit with suggestions to fix tests [failures](https://github.com/in-toto/in-toto-rs/actions/runs/3696777422/jobs/6260932784#step:3:523) in `verifylib.rs`.