### PR TITLE
layout: address deprecated method warning

### DIFF
--- a/src/models/layout/mod.rs
+++ b/src/models/layout/mod.rs
@@ -3,7 +3,6 @@
 use std::collections::BTreeMap;
 
 use chrono::prelude::*;
-use chrono::TimeZone;
 use chrono::{DateTime, Utc};
 use log::warn;
 use serde_derive::{Deserialize, Serialize};
@@ -74,7 +73,8 @@ impl Layout {
 }
 
 fn parse_datetime(ts: &str) -> Result<DateTime<Utc>> {
-    Utc.datetime_from_str(ts, "%FT%TZ")
+    DateTime::parse_from_str(ts, "%FT%TZ")
+        .map(Into::into)
         .map_err(|e| Error::Encoding(format!("Can't parse DateTime: {:?}", e)))
 }
 


### PR DESCRIPTION
```
warning: use of deprecated method `chrono::TimeZone::datetime_from_str`:
use `DateTime::parse_from_str` instead
  --> src/models/layout/mod.rs:77:9
   |
77 |     Utc.datetime_from_str(ts, "%FT%TZ")
   |         ^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
```