### PR TITLE
Minor bug- and clippy fixes

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -305,13 +305,13 @@ pub enum KeyType {
 impl KeyType {
     pub fn from_oid(oid: &[u8]) -> Result<Self> {
         match oid {
-            x if x == RSA_SPKI_OID => Ok(KeyType::Rsa),
-            x if x == ED25519_SPKI_OID => Ok(KeyType::Ed25519),
-            x if x == ECC_SPKI_OID => Ok(KeyType::Ecdsa),
-            x => Err(Error::Encoding(format!(
-                "Unknown OID: {}",
-                x.iter().map(|b| format!("{:x}", b)).collect::<String>()
-            ))),
+            RSA_SPKI_OID => Ok(KeyType::Rsa),
+            ED25519_SPKI_OID => Ok(KeyType::Ed25519),
+            ECC_SPKI_OID => Ok(KeyType::Ecdsa),
+            oid => {
+                let oid = HEXLOWER.encode(oid);
+                Err(Error::Encoding(format!("Unknown OID: {}", oid)))
+            }
         }
     }
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -147,10 +147,7 @@ fn shim_public_key(
         }
     };
 
-    let private_key = match private_key {
-        true => Some(""),
-        false => None,
-    };
+    let private_key = private_key.then_some("");
 
     Ok(shims::PublicKey::new(
         key_type.clone(),

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -533,7 +533,7 @@ impl PrivateKey {
     }
 
     fn rsa_from_pkcs8(der_key: &[u8], scheme: SignatureScheme) -> Result<Self> {
-        if let SignatureScheme::Ed25519 = scheme {
+        if SignatureScheme::Ed25519 == scheme {
             return Err(Error::IllegalArgument(
                 "RSA keys do not support the Ed25519 signing scheme".into(),
             ));

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -428,8 +428,7 @@ impl PrivateKey {
             ));
         }
 
-        let private_key_bytes = &key[..ED25519_PRIVATE_KEY_LENGTH];
-        let public_key_bytes = &key[ED25519_PUBLIC_KEY_LENGTH..];
+        let (private_key_bytes, public_key_bytes) = key.split_at(ED25519_PRIVATE_KEY_LENGTH);
 
         let key = Ed25519KeyPair::from_seed_and_public_key(private_key_bytes, public_key_bytes)
             .map_err(|err| Error::Encoding(err.to_string()))?;

--- a/src/interchange/cjson/mod.rs
+++ b/src/interchange/cjson/mod.rs
@@ -255,10 +255,10 @@ impl DataInterchange for Json {
     ///     r#"{"o":{"0":null,"a":[1,2,3],"f":false,"n":123,"s":"string","t":true}}"#
     /// );
     /// ```
-    fn to_writer<W, T: Sized>(mut writer: W, value: &T) -> Result<()>
+    fn to_writer<W, T>(mut writer: W, value: &T) -> Result<()>
     where
         W: Write,
-        T: Serialize,
+        T: Serialize + Sized,
     {
         let bytes = Self::canonicalize(&Self::serialize(value)?)?;
         writer.write_all(&bytes)?;

--- a/src/interchange/cjson/pretty.rs
+++ b/src/interchange/cjson/pretty.rs
@@ -118,10 +118,10 @@ impl DataInterchange for JsonPretty {
     ///   }
     /// }"#);
     /// ```
-    fn to_writer<W, T: Sized>(writer: W, value: &T) -> Result<()>
+    fn to_writer<W, T>(writer: W, value: &T) -> Result<()>
     where
         W: Write,
-        T: Serialize,
+        T: Serialize + Sized,
     {
         Ok(serde_json::to_writer_pretty(
             writer,

--- a/src/interchange/mod.rs
+++ b/src/interchange/mod.rs
@@ -33,10 +33,10 @@ pub trait DataInterchange: Debug + PartialEq + Clone {
 
     /// Write a struct to a stream.
     #[allow(clippy::wrong_self_convention)]
-    fn to_writer<W, T: Sized>(writer: W, value: &T) -> Result<()>
+    fn to_writer<W, T>(writer: W, value: &T) -> Result<()>
     where
         W: Write,
-        T: Serialize;
+        T: Serialize + Sized;
 
     /// Read a struct from a stream.
     fn from_reader<R, T>(rdr: R) -> Result<T>

--- a/src/models/layout/mod.rs
+++ b/src/models/layout/mod.rs
@@ -53,9 +53,10 @@ impl Layout {
         let keys_with_correct_key_id = self
             .keys
             .into_iter()
-            .filter(|(key_id, pkey)| match key_id == pkey.key_id() {
-                true => true,
-                false => {
+            .filter(|(key_id, pkey)| {
+                if key_id == pkey.key_id() {
+                    true
+                } else {
                     warn!("Malformed key of ID {:?}", key_id);
                     false
                 }

--- a/src/models/layout/step.rs
+++ b/src/models/layout/step.rs
@@ -21,8 +21,8 @@ impl Command {
     }
 }
 
-impl AsRef<Vec<String>> for Command {
-    fn as_ref(&self) -> &Vec<String> {
+impl AsRef<[String]> for Command {
+    fn as_ref(&self) -> &[String] {
         &self.0
     }
 }

--- a/src/verifylib.rs
+++ b/src/verifylib.rs
@@ -401,9 +401,10 @@ fn get_summary_link(
     name: &str,
 ) -> Result<Metablock> {
     let builder = LinkMetadataBuilder::new();
-    let link_metadata = match layout.steps.is_empty() {
-        true => builder.build()?,
-        false => builder
+    let link_metadata = if layout.steps.is_empty() {
+        builder.build()?
+    } else {
+        builder
             .materials(reduced_link_files[layout.steps[0].name()].materials.clone())
             .products(
                 reduced_link_files[layout.steps[layout.steps.len() - 1].name()]
@@ -421,7 +422,7 @@ fn get_summary_link(
                     .clone(),
             )
             .name(name.to_string())
-            .build()?,
+            .build()?
     };
     Metablock::new(MetadataWrapper::Link(link_metadata), &[])
 }


### PR DESCRIPTION
A very brief list of what was changed:

- In `KeyType::from_ed25519_with_keyid_hash_algorithms` it's using `&key[..ED25519_PRIVATE_KEY_LENGTH]` and then `&key[ED25519_PUBLIC_KEY_LENGTH..]`, while the "correct" thing would be `&key[ED25519_PRIVATE_KEY_LENGTH..]` to refer to the bytes after the private key. This ultimately doesn't matter at all in the final binary though, since both constants are 32. This patch changes it to `let (private_key_bytes, public_key_bytes) = key.split_at(ED25519_PRIVATE_KEY_LENGTH);`
- In the error message for unknown oid's, it's encoding each byte in a byte array to hex using `{:x}`, this works as expected for `0x10` to `0xff`, but for values like `0x00` to `0x0f` it would print `0` and `f` respectively. The byte sequence `[0x0f, 0x77, 0x0f]` would get hex encoded as `f77f`, suggesting `[0xf7, 0x7f]`. This is inside of an error branch though and doesn't have any real impact on the library.
- A few `match bool { true => {}, false => {} };` expressions have been rewritten to `if bool { ... } else { ... }` or `.then_some(...)`.
- Instead of `impl AsRef<Vec<String>> for Command {` do `impl AsRef<[String]> for Command {` because with an immutable reference, a Vec (pointer + length + capacity) doesn't have any benefits over a slice (pointer + length). This is technically a semver breaking change though.
- Instead of `x if x == ED25519_SPKI_OID => Ok(KeyType::Ed25519),` Rust supports writing just `ED25519_SPKI_OID => Ok(KeyType::Ed25519),`