### PR TITLE
Update Rust Edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "in-toto"
-edition = "2018"
+edition = "2021"
 version = "0.3.1"
 authors = ["Santiago Torres-Arias <santiagotorres@purdue.edu>",
            "Qijia 'Joy' Liu <joyliu.q@gmail.com>"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
-edition = "2018"
+edition = "2021"
 max_width = 80


### PR DESCRIPTION
Update to latest [Rust edition](https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html). The next edition is 2024.

There are no breaking changes, and it adds more consistency to the overall language. In order to miminize the risk of introducing "outdated" idioms to the implementation, updated the edition to 2021.
