### PR TITLE
Fix cargo clippy warnings

### DIFF
--- a/src/models/layout/mod.rs
+++ b/src/models/layout/mod.rs
@@ -109,13 +109,13 @@ mod test {
     fn parse_datetime_test() {
         let time_str = "1970-01-01T00:00:00Z".to_string();
         let parsed_dt = parse_datetime(&time_str[..]).unwrap();
-        let dt = DateTime::from_timestamp(0, 0).unwrap();
+        let dt = DateTime::UNIX_EPOCH;
         assert_eq!(parsed_dt, dt);
     }
 
     #[test]
     fn format_datetime_test() {
-        let dt = DateTime::from_timestamp(0, 0).unwrap();
+        let dt = DateTime::UNIX_EPOCH;
         let generated_dt_str = format_datetime(&dt);
         let dt_str = "1970-01-01T00:00:00Z".to_string();
         assert_eq!(dt_str, generated_dt_str);
@@ -129,7 +129,7 @@ mod test {
         )
         .unwrap();
         let metadata = LayoutMetadataBuilder::new()
-            .expires(DateTime::from_timestamp(0, 0).unwrap())
+            .expires(DateTime::UNIX_EPOCH)
             .add_key(alice_key.clone())
             .add_key(bob_key.clone())
             .add_step(

--- a/src/models/layout/mod.rs
+++ b/src/models/layout/mod.rs
@@ -87,7 +87,7 @@ fn format_datetime(ts: &DateTime<Utc>) -> String {
 #[cfg(test)]
 mod test {
     use assert_json_diff::assert_json_eq;
-    use chrono::{NaiveDateTime, TimeZone, Utc};
+    use chrono::DateTime;
     use serde_json::json;
 
     use crate::{crypto::PublicKey, models::layout::format_datetime};
@@ -109,17 +109,13 @@ mod test {
     fn parse_datetime_test() {
         let time_str = "1970-01-01T00:00:00Z".to_string();
         let parsed_dt = parse_datetime(&time_str[..]).unwrap();
-        let dt = Utc.from_utc_datetime(
-            &NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
-        );
+        let dt = DateTime::from_timestamp(0, 0).unwrap();
         assert_eq!(parsed_dt, dt);
     }
 
     #[test]
     fn format_datetime_test() {
-        let dt = Utc.from_utc_datetime(
-            &NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
-        );
+        let dt = DateTime::from_timestamp(0, 0).unwrap();
         let generated_dt_str = format_datetime(&dt);
         let dt_str = "1970-01-01T00:00:00Z".to_string();
         assert_eq!(dt_str, generated_dt_str);
@@ -133,9 +129,7 @@ mod test {
         )
         .unwrap();
         let metadata = LayoutMetadataBuilder::new()
-            .expires(Utc.from_utc_datetime(
-                &NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
-            ))
+            .expires(DateTime::from_timestamp(0, 0).unwrap())
             .add_key(alice_key.clone())
             .add_key(bob_key.clone())
             .add_step(

--- a/src/models/metadata.rs
+++ b/src/models/metadata.rs
@@ -313,7 +313,7 @@ mod tests {
     use std::{fs, str::FromStr};
 
     use assert_json_diff::assert_json_eq;
-    use chrono::{NaiveDateTime, TimeZone, Utc};
+    use chrono::DateTime;
     use serde_json::json;
 
     use crate::{
@@ -363,9 +363,7 @@ mod tests {
             PrivateKey::from_ed25519(OWNER_PRIVATE_KEY).unwrap();
         let layout_metadata = Box::new(
             LayoutMetadataBuilder::new()
-                .expires(Utc.from_utc_datetime(
-                    &NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
-                ))
+                .expires(DateTime::from_timestamp(0, 0).unwrap())
                 .add_key(alice_public_key.clone())
                 .add_key(bob_public_key.clone())
                 .add_step(

--- a/src/models/metadata.rs
+++ b/src/models/metadata.rs
@@ -2,9 +2,11 @@
 //! # Metadata & MetadataWrapper
 //! Metadata is the top level abstract for both layout metadata and link
 //! metadata. Metadata it is devided into two types
+//!
 //! * enum `MetadataWrapper` is used to do serialize, deserialize and
-//! other object unsafe operations.
+//!   other object unsafe operations.
 //! * trait `Metadata` is used to work for trait object.
+//!
 //! The reason please refer to issue <https://github.com/in-toto/in-toto-rs/issues/33>
 //!
 //! # Metablock
@@ -112,7 +114,7 @@ pub trait Metadata {
 /// All signed files (link and layout files) have the format.
 /// * `signatures`: A pubkey => signature map. signatures are for the metadata.
 /// * `metadata`: <ROLE> dictionary. Also known as signed metadata. e.g., link
-/// or layout.
+///   or layout.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Metablock {
     pub signatures: Vec<Signature>,

--- a/src/models/metadata.rs
+++ b/src/models/metadata.rs
@@ -363,7 +363,7 @@ mod tests {
             PrivateKey::from_ed25519(OWNER_PRIVATE_KEY).unwrap();
         let layout_metadata = Box::new(
             LayoutMetadataBuilder::new()
-                .expires(DateTime::from_timestamp(0, 0).unwrap())
+                .expires(DateTime::UNIX_EPOCH)
                 .add_key(alice_public_key.clone())
                 .add_key(bob_public_key.clone())
                 .add_step(

--- a/src/rulelib.rs
+++ b/src/rulelib.rs
@@ -24,6 +24,7 @@ fn canonicalize_path(path: &VirtualTargetPath) -> Option<VirtualTargetPath> {
 /// * `src_artifacts`: artifacts of a given link (either Products or Materials)
 /// * `src_artifact_queue`: artifact paths (canonicalized) of the same link (either Products or Materials)
 /// * `items_metadata`: a <name> to <link> hashmap
+///
 /// This function will match the artifact paths of `src_artifact_queue`
 /// and the `dst_artifacts`. Here `dst_artifacts` can be calculated
 /// by indexing the step name from `items_metadata`. Return value is

--- a/src/verifylib.rs
+++ b/src/verifylib.rs
@@ -478,7 +478,6 @@ fn get_summary_link(
 ///
 /// 1. Verify layout signature(s) using passed key(s)
 /// 2. Verify layout expiration date
-/// // 3. Substitute parameters in layout
 /// 3. Load link metadata files for steps of layout
 /// 4. Verify signatures and signature thresholds for steps of layout
 /// 5. Verify sublayouts recursively
@@ -496,7 +495,7 @@ fn get_summary_link(
 /// * `layout_keys`: A `key_id` to `Pubkey` map defined in layout.
 /// * `link_dir`: The directory where link files are stored.
 /// * `step_name`(Optional): A name assigned to the returned link. This is mostly
-/// useful during recursive sublayout verification.
+///   useful during recursive sublayout verification.
 ///
 /// # Side-Effects
 /// * I/O: Read link files from the disk.
@@ -504,7 +503,7 @@ fn get_summary_link(
 ///
 /// # Return Value
 /// * A LinkMetadata which summarizes the materials
-/// and products of the whole software supply chain.
+///   and products of the whole software supply chain.
 pub fn in_toto_verify(
     layout: &Metablock,
     layout_keys: HashMap<KeyId, PublicKey>,


### PR DESCRIPTION
Removed unnecessary `to_string()` calls.
