### PR TITLE
Reduce number of dependencies, update versions, fix clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,43 +19,31 @@ path = "./src/lib.rs"
 
 [dependencies]
 chrono = { version = "0.4", features = [ "clock", "serde" ], default-features = false }
-data-encoding = "2.0.0-rc.2"
+data-encoding = "2"
 derp = "0.0.14"
-futures-executor = "0.3.1"
-futures-io = "0.3.1"
-futures-util = { version = "0.3.1", features = [ "compat", "io" ] }
-http = "1.0"
-hyper = { version = "1.0", default-features = false }
 itoa = "1"
 log = "0.4"
 ring = { version = "0.17" }
-parking_lot = "0.12"
-percent-encoding = "2.1"
-serde = "1"
-serde_derive = "1"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tempfile = "3"
 untrusted = "0.7"
-url = "2"
 thiserror = "1.0"
 walkdir = "2"
 path-clean = "1.0.1"
-rand = "0.8.4"
-lazy_static = "1.4.0"
-once_cell = "1.10.0"
-strum = "0.25"
-strum_macros = "0.25"
+strum = "0.26"
+strum_macros = "0.26"
 pem = "3.0.0"
-path-matchers = "1.0.2"
 glob = "0.3.0"
 
 [dev-dependencies]
+assert-json-diff = "2.0.2"
 lazy_static = "1"
 maplit = "1"
 matches = "0.1.8"
+once_cell = "1.10.0"
 pretty_assertions = "1.3"
-assert-json-diff = "2.0.2"
 rstest = "0.19.0"
+tempfile = "3"
 
 [features]
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -9,9 +9,9 @@ use ring::signature::{
     ECDSA_P256_SHA256_ASN1_SIGNING, ED25519, RSA_PSS_2048_8192_SHA256,
     RSA_PSS_2048_8192_SHA512, RSA_PSS_SHA256, RSA_PSS_SHA512,
 };
-use serde::de::{Deserialize, Deserializer, Error as DeserializeError};
-use serde::ser::{Error as SerializeError, Serialize, Serializer};
-use serde_derive::{Deserialize, Serialize};
+use serde::de::{Deserializer, Error as DeserializeError};
+use serde::ser::{Error as SerializeError, Serializer};
+use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt::{self, Debug, Display};

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -350,14 +350,18 @@ impl FromStr for KeyType {
     }
 }
 
-impl ToString for KeyType {
-    fn to_string(&self) -> String {
-        match *self {
-            KeyType::Ed25519 => "ed25519".to_string(),
-            KeyType::Rsa => "rsa".to_string(),
-            KeyType::Ecdsa => "ecdsa".to_string(),
-            KeyType::Unknown(ref s) => s.to_string(),
-        }
+impl fmt::Display for KeyType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match *self {
+                KeyType::Ed25519 => "ed25519",
+                KeyType::Rsa => "rsa",
+                KeyType::Ecdsa => "ecdsa",
+                KeyType::Unknown(ref s) => s,
+            }
+        )
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -96,18 +96,6 @@ impl From<io::Error> for Error {
     }
 }
 
-impl From<http::Error> for Error {
-    fn from(err: http::Error) -> Error {
-        Error::Opaque(format!("Http: {:?}", err))
-    }
-}
-
-impl From<hyper::Error> for Error {
-    fn from(err: hyper::Error) -> Error {
-        Error::Opaque(format!("Hyper: {:?}", err))
-    }
-}
-
 impl From<DecodeError> for Error {
     fn from(err: DecodeError) -> Error {
         Error::Encoding(format!("{:?}", err))
@@ -117,12 +105,6 @@ impl From<DecodeError> for Error {
 impl From<derp::Error> for Error {
     fn from(err: derp::Error) -> Error {
         Error::Encoding(format!("DER: {:?}", err))
-    }
-}
-
-impl From<tempfile::PersistError> for Error {
-    fn from(err: tempfile::PersistError) -> Error {
-        Error::Opaque(format!("Error persisting temp file: {:?}", err))
     }
 }
 

--- a/src/interchange/cjson/mod.rs
+++ b/src/interchange/cjson/mod.rs
@@ -184,7 +184,7 @@ impl DataInterchange for Json {
     }
 
     /// ```
-    /// # use serde_derive::Deserialize;
+    /// # use serde::Deserialize;
     /// # use serde_json::json;
     /// # use std::collections::HashMap;
     /// # use in_toto::interchange::{DataInterchange, Json};
@@ -210,7 +210,7 @@ impl DataInterchange for Json {
     }
 
     /// ```
-    /// # use serde_derive::Serialize;
+    /// # use serde::Serialize;
     /// # use serde_json::json;
     /// # use std::collections::HashMap;
     /// # use in_toto::interchange::{DataInterchange, Json};

--- a/src/interchange/cjson/pretty.rs
+++ b/src/interchange/cjson/pretty.rs
@@ -37,7 +37,7 @@ impl DataInterchange for JsonPretty {
     }
 
     /// ```
-    /// # use serde_derive::Deserialize;
+    /// # use serde::Deserialize;
     /// # use serde_json::json;
     /// # use std::collections::HashMap;
     /// # use in_toto::interchange::{DataInterchange, JsonPretty};
@@ -63,7 +63,7 @@ impl DataInterchange for JsonPretty {
     }
 
     /// ```
-    /// # use serde_derive::Serialize;
+    /// # use serde::Serialize;
     /// # use serde_json::json;
     /// # use std::collections::HashMap;
     /// # use in_toto::interchange::{DataInterchange, JsonPretty};

--- a/src/interchange/cjson/shims.rs
+++ b/src/interchange/cjson/shims.rs
@@ -2,7 +2,7 @@
 //use chrono::offset::Utc;
 //use chrono::prelude::*;
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::crypto;
 

--- a/src/models/envelope/envelope_file.rs
+++ b/src/models/envelope/envelope_file.rs
@@ -1,4 +1,4 @@
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::interchange::DataInterchange;
 use crate::Result;

--- a/src/models/helpers.rs
+++ b/src/models/helpers.rs
@@ -1,5 +1,6 @@
 //! Supporting Functions and Types (VirtualTargetPath)
 use std::collections::HashMap;
+use std::fmt;
 use std::fmt::Debug;
 use std::str;
 
@@ -40,9 +41,9 @@ impl VirtualTargetPath {
     }
 }
 
-impl ToString for VirtualTargetPath {
-    fn to_string(&self) -> String {
-        self.0.clone()
+impl fmt::Display for VirtualTargetPath {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/src/models/helpers.rs
+++ b/src/models/helpers.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use std::str;
 
 use serde::de::{Deserialize, Deserializer, Error as DeserializeError};
-use serde_derive::Serialize;
+use serde::Serialize;
 
 use crate::crypto::{HashAlgorithm, HashValue};
 use crate::{Error, Result};

--- a/src/models/layout/inspection.rs
+++ b/src/models/layout/inspection.rs
@@ -1,6 +1,6 @@
 //! in-toto layout's Inspection
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::supply_chain_item_derive;
 

--- a/src/models/layout/mod.rs
+++ b/src/models/layout/mod.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use chrono::prelude::*;
 use chrono::{DateTime, Utc};
 use log::warn;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::crypto::{KeyId, PublicKey};
 use crate::{Error, Result};

--- a/src/models/layout/step.rs
+++ b/src/models/layout/step.rs
@@ -2,8 +2,8 @@
 
 use std::str::FromStr;
 
-use serde::ser::{Serialize, Serializer};
-use serde_derive::{Deserialize, Serialize};
+use serde::ser::Serializer;
+use serde::{Deserialize, Serialize};
 
 use crate::crypto::KeyId;
 use crate::{supply_chain_item_derive, Error, Result};

--- a/src/models/link/byproducts.rs
+++ b/src/models/link/byproducts.rs
@@ -2,7 +2,7 @@
 //!
 use std::collections::BTreeMap;
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 /// byproducts of a link file
 /// # Example

--- a/src/models/link/mod.rs
+++ b/src/models/link/mod.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use std::str;
 
 use crate::Result;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 pub mod byproducts;
 mod metadata;

--- a/src/models/metadata.rs
+++ b/src/models/metadata.rs
@@ -15,7 +15,7 @@
 //! create signatures.
 
 use log::{debug, warn};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::str;

--- a/src/models/predicate/link_v02.rs
+++ b/src/models/predicate/link_v02.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::{PredicateLayout, PredicateVer, PredicateWrapper};
 use crate::interchange::{DataInterchange, Json};

--- a/src/models/predicate/mod.rs
+++ b/src/models/predicate/mod.rs
@@ -10,9 +10,9 @@ use serde_json::Value;
 pub use slsa_provenance_v01::SLSAProvenanceV01;
 pub use slsa_provenance_v02::SLSAProvenanceV02;
 
-use serde::de::{Deserialize, Deserializer, Error as DeserializeError};
-use serde::ser::{Serialize, Serializer};
-use serde_derive::Serialize;
+use serde::de::{Deserializer, Error as DeserializeError};
+use serde::ser::Serializer;
+use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 

--- a/src/models/predicate/slsa_provenance_v01.rs
+++ b/src/models/predicate/slsa_provenance_v01.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
 use chrono::{DateTime, FixedOffset, SecondsFormat};
-use serde::de::{Deserialize, Deserializer, Error as DeserializeError};
-use serde::ser::{Serialize, Serializer};
-use serde_derive::{Deserialize, Serialize};
+use serde::de::{Deserializer, Error as DeserializeError};
+use serde::ser::Serializer;
+use serde::{Deserialize, Serialize};
 
 use super::{PredicateLayout, PredicateVer, PredicateWrapper};
 use crate::interchange::{DataInterchange, Json};

--- a/src/models/predicate/slsa_provenance_v02.rs
+++ b/src/models/predicate/slsa_provenance_v02.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::slsa_provenance_v01::{
     Builder, Material, ProvenanceMetadata, TypeURI,

--- a/src/models/statement/mod.rs
+++ b/src/models/statement/mod.rs
@@ -7,9 +7,9 @@ pub use state_v01::StateV01;
 use std::convert::TryFrom;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-use serde::de::{Deserialize, Deserializer, Error as DeserializeError};
-use serde::ser::{Serialize, Serializer};
-use serde_derive::Serialize;
+use serde::de::{Deserializer, Error as DeserializeError};
+use serde::ser::Serializer;
+use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 

--- a/src/models/statement/state_naive.rs
+++ b/src/models/statement/state_naive.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, fmt::Debug};
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::{FromMerge, StateLayout, StatementVer, StatementWrapper};
 use crate::models::{LinkMetadata, TargetDescription, VirtualTargetPath};

--- a/src/models/statement/state_v01.rs
+++ b/src/models/statement/state_v01.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     interchange::{DataInterchange, Json},

--- a/src/runlib.rs
+++ b/src/runlib.rs
@@ -143,8 +143,7 @@ pub fn record_artifacts(
                         )?;
                         if artifacts.contains_key(&virtual_target_path) {
                             return Err(Error::LinkGatheringError(format!(
-                                "non unique stripped path {}",
-                                virtual_target_path.to_string()
+                                "non unique stripped path {virtual_target_path}"
                             )));
                         }
                         artifacts.insert(virtual_target_path, hashes);
@@ -157,8 +156,7 @@ pub fn record_artifacts(
                     record_artifact(&path, hash_algorithms, lstrip_paths)?;
                 if artifacts.contains_key(&virtual_target_path) {
                     return Err(Error::LinkGatheringError(format!(
-                        "non unique stripped path {}",
-                        virtual_target_path.to_string()
+                        "non unique stripped path {virtual_target_path}"
                     )));
                 }
                 artifacts.insert(virtual_target_path, hashes);


### PR DESCRIPTION
Hi! :wave: 

I've moved some dependencies into `[dev-dependencies]` and some could be removed entirely. :)

Since this removes some `impl From<...>` cases this is technically a breaking change in the public API and should be released as `0.4.0` instead of `0.3.2`.

This also fixes two clippy warnings.