### PR TITLE
Update `untrusted` and `derp` dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ path = "./src/lib.rs"
 [dependencies]
 chrono = { version = "0.4", features = [ "clock", "serde" ], default-features = false }
 data-encoding = "2"
-derp = "0.0.14"
+derp = "0.0.15"
 itoa = "1"
 log = "0.4"
 ring = { version = "0.17" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-untrusted = "0.7"
+untrusted = "0.9"
 thiserror = "2.0"
 walkdir = "2"
 path-clean = "1.0.1"

--- a/src/models/envelope/pae_v1.rs
+++ b/src/models/envelope/pae_v1.rs
@@ -47,7 +47,7 @@ impl DSSEParser for PaeV1 {
             "{prefix}{split}{payload_ver_len}{split}{payload_ver}{split}{payload_len}{split}",
             prefix = PREFIX,
             split = SPLIT,
-            payload_ver_len = payload_ver.as_bytes().len(),
+            payload_ver_len = payload_ver.len(),
             payload_ver = payload_ver.as_str(),
             payload_len = payload.len(),
         );


### PR DESCRIPTION
This resolves #102, these two crates need to be updated together.